### PR TITLE
Build 0.3.26

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "croniter" %}
-{% set version = "0.3.27" %}
+{% set version = "0.3.26" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "fbd72189a0ff38c27e953d15175c5fedafb953479559240a1afcf8e8e7523757" %}
+{% set hash = "4fcbcc6515d5721a975e065bb77f22e6e990eb0c1a023c454a661b871150d9f1" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  url: https://github.com/kiorky/croniter/archive/0.3.26.tar.gz
   {{ hash_type }}: {{ hash }}
 
 build:


### PR DESCRIPTION
Note the url is special because 0.3.26 was deleted from PyPi by mistake and can't be re-uploaded.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [*] Used a fork of the feedstock to propose changes
* [*] Bumped the build number (if the version is unchanged)
* [*] Reset the build number to `0` (if the version changed)
* [*] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
```
@ conda-forge-admin, please rerender
```
* [*] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
